### PR TITLE
Unnecessary requiring ruby-growl and xmpp4r when false on setup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,12 @@
 PATH
   remote: .
   specs:
-    uniform_notifier (0.0.1)
+    uniform_notifier (1.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
-    rspec (2.1.0)
-      rspec-core (~> 2.1.0)
-      rspec-expectations (~> 2.1.0)
-      rspec-mocks (~> 2.1.0)
-    rspec-core (2.1.0)
-    rspec-expectations (2.1.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.1.0)
+    rspec (1.3.1)
     ruby-growl (3.0)
     xmpp4r (0.5)
 
@@ -22,7 +14,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rspec
-  ruby-growl
+  rspec (= 1.3.1)
+  ruby-growl (= 3.0)
   uniform_notifier!
-  xmpp4r
+  xmpp4r (= 0.5)

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+require "spec/rake/spectask"
+Spec::Rake::SpecTask.new

--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -12,8 +12,9 @@ module UniformNotifier
     end
 
     def self.setup_connection( growl )
+      return unless growl
       require 'ruby-growl'
-      @password = growl == true ? nil : growl[:password]
+      @password = growl.instance_of?(Hash) ? growl[:password] : nil
       @growl = connect
 
       notify 'Uniform Notifier Growl has been turned on'

--- a/lib/uniform_notifier/version.rb
+++ b/lib/uniform_notifier/version.rb
@@ -1,3 +1,3 @@
 module UniformNotifier
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/uniform_notifier/xmpp.rb
+++ b/lib/uniform_notifier/xmpp.rb
@@ -14,6 +14,8 @@ module UniformNotifier
     end
 
     def self.setup_connection( xmpp_information )
+      return unless xmpp_information
+
       require 'xmpp4r'
 
       @receiver = xmpp_information[:receiver]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
 require "uniform_notifier"
-require "rspec"
+require "rubygems"
+require "ruby-growl"
+require "xmpp4r"
+require "spec"

--- a/spec/uniform_notifier/growl_spec.rb
+++ b/spec/uniform_notifier/growl_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'ruby-growl'
 
 describe UniformNotifier::Growl do
 

--- a/spec/uniform_notifier/xmpp_spec.rb
+++ b/spec/uniform_notifier/xmpp_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'xmpp4r'
 
 describe UniformNotifier::Xmpp do
   it "should not notify xmpp" do

--- a/uniform_notifier.gemspec
+++ b/uniform_notifier.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "uniform_notifier"
 
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "ruby-growl"
-  s.add_development_dependency "xmpp4r"
+  s.add_development_dependency "ruby-growl", "3.0"
+  s.add_development_dependency "xmpp4r", "0.5"
+  s.add_development_dependency "rspec", "1.3.1"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
If I configure Bullet.growl = false, it's requiring load ruby-growl. The same for xmpp4r.
