### PR TITLE
Add support for ruby_gntp which is needed for Growl v1.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Growl Support
 
 To get Growl support up-and-running, follow the steps below:
 
-* Install the ruby-growl gem: <code>gem install ruby-growl</code>
+* For Growl < v1.3, install the ruby-growl gem: <code>gem install ruby-growl</code>
+* For Growl v1.3+, install the ruby_gntp gem: <code>gem install ruby_gntp</code>
 * Open the Growl preference pane in Systems Preferences
 * Click the "Network" tab
 * Make sure both "Listen for incoming notifications" and "Allow remote application registration" are checked. *Note*: If you set a password, you will need to set <code>UniformNotifier.growl_password = { :password => 'growl password' }</code> in the config file.

--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -12,28 +12,54 @@ module UniformNotifier
     end
 
     def self.setup_connection( growl )
+      setup_connection_growl(growl)
+    rescue LoadError
+      begin
+        setup_connection_gntp(growl)
+      rescue LoadError
+        @growl = nil
+        raise NotificationError.new( 'You must install the ruby-growl or the ruby_gntp gem to use Growl notification: `gem install ruby-growl` or `gem install ruby_gntp`' )
+      end
+    end
+
+    def self.setup_connection_growl( growl )
       return unless growl
       require 'ruby-growl'
       @password = growl.instance_of?(Hash) ? growl[:password] : nil
-      @growl = connect
+      @growl = ::Growl.new('localhost',
+                           'uniform_notifier',
+                           [ 'uniform_notifier' ],
+                           nil,
+                           @password)
 
       notify 'Uniform Notifier Growl has been turned on'
-    rescue LoadError
-      @growl = nil
-      raise NotificationError.new( 'You must install the ruby-growl gem to use Growl notification: `gem install ruby-growl`' )
+    end
+
+    def self.setup_connection_growl( growl )
+      return unless growl
+      require 'ruby_gntp'
+      @password = growl.instance_of?(Hash) ? growl[:password] : nil
+      @growl = GNTP.new('uniform_notifier', 'localhost', @password, 23053)
+      @growl.register({:notifications => [{
+                                            :name     => 'uniform_notifier',
+                                            :enabled  => true,
+                                          }]})
+
+      notify 'Uniform Notifier Growl has been turned on (using GNTP)'
     end
 
     private
-      def self.connect
-        ::Growl.new 'localhost',
-                    'uniform_notifier',
-                    [ 'uniform_notifier' ],
-                    nil,
-                    @password
-      end
-
       def self.notify( message )
-        @growl.notify( 'uniform_notifier', 'Uniform Notifier', message )
+        case @growl
+        when Growl
+          @growl.notify( 'uniform_notifier', 'Uniform Notifier', message )
+        when GNTP
+          @growl.notify({
+                          :name  => 'uniform_notifier',
+                          :title => 'Uniform Notifier',
+                          :text  => message
+                        })
+        end
       end
+    end
   end
-end


### PR DESCRIPTION
OSX Lion uses Growl 1.3, which seems to need GNTP to work. I'm not sure if ruby-growl can be made to work with 1.3, but ruby_gntp certainly works.
