### PR TITLE
Fix 'Invalid gemspec #<YAML::Syck::DefaultKey:...>'

### DIFF
--- a/uniform_notifier.gemspec
+++ b/uniform_notifier.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "uniform_notifier"
 
-  s.add_development_dependency "ruby-growl", "3.0"
-  s.add_development_dependency "ruby_gntp", "0.3.4"
-  s.add_development_dependency "xmpp4r", "0.5"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency %q<ruby-growl>, ["= 3.0"]
+  s.add_development_dependency %q<ruby_gntp>, ["= 0.3.4"]
+  s.add_development_dependency %q<xmpp4r>, ["= 0.5"]
+  s.add_development_dependency %q<rspec>, ["> 0"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Fix 'Invalid gemspec '#<YAML::Syck::DefaultKey:0x101bfa3b8>' for ruby 1.8.7 that contains yaml version <= 0.6. Ref #6
