### PR TITLE
Added :quiet option to growl to disable the "has been turned on" message

### DIFF
--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -30,7 +30,7 @@ module UniformNotifier
       @growl.add_notification 'uniform_notifier'
       @growl.password = @password
 
-      notify 'Uniform Notifier Growl has been turned on'
+      notify 'Uniform Notifier Growl has been turned on' unless growl[:quiet]
     end
 
     def self.setup_connection_gntp( growl )
@@ -43,7 +43,7 @@ module UniformNotifier
                                             :enabled  => true,
                                           }]})
 
-      notify 'Uniform Notifier Growl has been turned on (using GNTP)'
+      notify 'Uniform Notifier Growl has been turned on (using GNTP)' unless growl[:quiet]
     end
 
     private


### PR DESCRIPTION
That welcome message has been bugging me lately, I'd prefer to only get notifications when Bullet needs to grab my attention, rather than every time I bounce the server.
