### PR TITLE
Use custom exception

### DIFF
--- a/lib/uniform_notifier.rb
+++ b/lib/uniform_notifier.rb
@@ -1,4 +1,5 @@
 require 'uniform_notifier/base'
+require 'uniform_notifier/errors'
 require 'uniform_notifier/javascript_alert'
 require 'uniform_notifier/javascript_console'
 require 'uniform_notifier/growl'

--- a/lib/uniform_notifier/errors.rb
+++ b/lib/uniform_notifier/errors.rb
@@ -1,0 +1,3 @@
+module UniformNotifier
+  class Exception < ::Exception; end
+end

--- a/lib/uniform_notifier/raise.rb
+++ b/lib/uniform_notifier/raise.rb
@@ -1,7 +1,5 @@
 module UniformNotifier
   class Raise < Base
-    class UniformNotifierException < Exception; end
-
     def self.active?
       @exception_class
     end
@@ -13,7 +11,7 @@ module UniformNotifier
     end
 
     def self.setup_connection(exception_class)
-      @exception_class = exception_class == true ? UniformNotifierException : exception_class
+      @exception_class = exception_class == true ? Exception : exception_class
     end
   end
 end

--- a/spec/uniform_notifier/airbrake_spec.rb
+++ b/spec/uniform_notifier/airbrake_spec.rb
@@ -10,7 +10,7 @@ describe UniformNotifier::AirbrakeNotifier do
   end
 
   it "should notify airbrake" do
-    Airbrake.should_receive(:notify).with(Exception.new("notify airbrake"))
+    Airbrake.should_receive(:notify).with(UniformNotifier::Exception.new("notify airbrake"))
 
     UniformNotifier.airbrake = true
     UniformNotifier::AirbrakeNotifier.out_of_channel_notify("notify airbrake")

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -10,7 +10,7 @@ describe UniformNotifier::BugsnagNotifier do
   end
 
   it "should notify bugsnag" do
-    Bugsnag.should_receive(:notify).with(Exception.new("notify bugsnag"))
+    Bugsnag.should_receive(:notify).with(UniformNotifier::Exception.new("notify bugsnag"))
 
     UniformNotifier.bugsnag = true
     UniformNotifier::BugsnagNotifier.out_of_channel_notify("notify bugsnag")

--- a/spec/uniform_notifier/raise_spec.rb
+++ b/spec/uniform_notifier/raise_spec.rb
@@ -9,7 +9,7 @@ describe UniformNotifier::Raise do
     UniformNotifier.raise = true
     expect {
       UniformNotifier::Raise.out_of_channel_notify("notification")
-    }.to raise_error(UniformNotifier::Raise::UniformNotifierException, "notification")
+    }.to raise_error(UniformNotifier::Exception, "notification")
   end
 
   it "allows the user to override the default exception class" do


### PR DESCRIPTION
Hi,

I think we should use custom exception instead of default Exception class in airbrake and bugsnag.
