### PR TITLE
Support detail notify data

### DIFF
--- a/lib/uniform_notifier/airbrake.rb
+++ b/lib/uniform_notifier/airbrake.rb
@@ -4,8 +4,11 @@ module UniformNotifier
       UniformNotifier.airbrake
     end
 
-    def self.out_of_channel_notify(message)
-      return unless active?
+    protected
+
+    def self._out_of_channel_notify(data)
+      message = data.values.compact.join("\n")
+
       exception = Exception.new(message)
       Airbrake.notify(exception)
     end

--- a/lib/uniform_notifier/base.rb
+++ b/lib/uniform_notifier/base.rb
@@ -4,16 +4,36 @@ module UniformNotifier
       false
     end
 
-    def self.inline_notify( message )
+    def self.inline_notify( data )
+      return unless active?
+
+      # For compatibility to the old protocol
+      data = { :title => data } if data.is_a?(String)
+
+      _inline_notify( data )
     end
 
-    def self.out_of_channel_notify( message )
+    def self.out_of_channel_notify( data )
+      return unless active?
+
+      # For compatibility to the old protocol
+      data = { :title => data } if data.is_a?(String)
+
+      _out_of_channel_notify(data)
     end
 
-    def self.wrap_js_association( message )
+    protected
+
+    def self._inline_notify( data )
+    end
+
+    def self._out_of_channel_notify( data )
+    end
+
+    def self.wrap_js_association( code )
       <<-CODE
 <script type="text/javascript">/*<![CDATA[*/
-#{message}
+#{code}
 /*]]>*/</script>
       CODE
     end

--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -4,8 +4,11 @@ module UniformNotifier
       UniformNotifier.bugsnag
     end
 
-    def self.out_of_channel_notify(message)
-      return unless active?
+    protected
+
+    def self._out_of_channel_notify(data)
+      message = data.values.compact.join("\n")
+
       exception = Exception.new(message)
       Bugsnag.notify(exception)
     end

--- a/lib/uniform_notifier/customized_logger.rb
+++ b/lib/uniform_notifier/customized_logger.rb
@@ -6,8 +6,8 @@ module UniformNotifier
       @logger
     end
 
-    def self.out_of_channel_notify( message )
-      return unless active?
+    def self._out_of_channel_notify( data )
+      message = data.values.compact.join("\n")
       @logger.warn message
     end
 

--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -6,11 +6,6 @@ module UniformNotifier
       @growl
     end
 
-    def self.out_of_channel_notify( message )
-      return unless active?
-      notify( message )
-    end
-
     def self.setup_connection( growl )
       setup_connection_growl(growl)
     rescue LoadError
@@ -44,6 +39,14 @@ module UniformNotifier
                                           }]})
 
       notify 'Uniform Notifier Growl has been turned on (using GNTP)' if !growl.instance_of?(Hash) || !growl[:quiet]
+    end
+    
+    protected
+
+    def self._out_of_channel_notify( data )
+      message = data.values.compact.join("\n")
+
+      notify( message )
     end
 
     private

--- a/lib/uniform_notifier/javascript_alert.rb
+++ b/lib/uniform_notifier/javascript_alert.rb
@@ -3,9 +3,11 @@ module UniformNotifier
     def self.active?
       UniformNotifier.alert
     end
+    
+    protected
 
-    def self.inline_notify( message )
-      return unless self.active?
+    def self._inline_notify( data )
+      message = data.values.compact.join("\n")
 
       wrap_js_association "alert( #{message.inspect} );"
     end

--- a/lib/uniform_notifier/javascript_console.rb
+++ b/lib/uniform_notifier/javascript_console.rb
@@ -4,8 +4,10 @@ module UniformNotifier
       UniformNotifier.console
     end
 
-    def self.inline_notify( message )
-      return unless active?
+    protected
+
+    def self._inline_notify( data )
+      message = data.values.compact.join("\n")
 
       code = <<-CODE
 if (typeof(console) !== 'undefined' && console.log) {

--- a/lib/uniform_notifier/rails_logger.rb
+++ b/lib/uniform_notifier/rails_logger.rb
@@ -4,8 +4,11 @@ module UniformNotifier
       UniformNotifier.rails_logger
     end
 
-    def self.out_of_channel_notify( message )
-      return unless active?
+    protected
+
+    def self._out_of_channel_notify( data )
+      message = data.values.compact.join("\n")
+
       Rails.logger.warn message
     end
   end

--- a/lib/uniform_notifier/raise.rb
+++ b/lib/uniform_notifier/raise.rb
@@ -4,14 +4,16 @@ module UniformNotifier
       @exception_class
     end
 
-    def self.out_of_channel_notify( message )
-      return unless self.active?
-
-      raise @exception_class, message
-    end
-
     def self.setup_connection(exception_class)
       @exception_class = exception_class == true ? Exception : exception_class
+    end
+
+    protected
+
+    def self._out_of_channel_notify( data )
+      message = data.values.compact.join("\n")
+
+      raise @exception_class, message
     end
   end
 end

--- a/lib/uniform_notifier/xmpp.rb
+++ b/lib/uniform_notifier/xmpp.rb
@@ -8,11 +8,6 @@ module UniformNotifier
       @xmpp
     end
 
-    def self.out_of_channel_notify( message )
-      return unless active?
-      notify( message )
-    end
-
     def self.setup_connection( xmpp_information )
       return unless xmpp_information
 
@@ -29,6 +24,14 @@ module UniformNotifier
     rescue LoadError
       @xmpp = nil
       raise NotificationError.new( 'You must install the xmpp4r gem to use XMPP notification: `gem install xmpp4r`' )
+    end
+
+    protected
+
+    def self._out_of_channel_notify( data )
+      message = data.values.compact.join("\n")
+
+      notify( message )
     end
 
     private

--- a/spec/uniform_notifier/airbrake_spec.rb
+++ b/spec/uniform_notifier/airbrake_spec.rb
@@ -6,13 +6,13 @@ end
 
 describe UniformNotifier::AirbrakeNotifier do
   it "should not notify airbrake" do
-    UniformNotifier::AirbrakeNotifier.out_of_channel_notify("notify airbrake").should be_nil
+    UniformNotifier::AirbrakeNotifier.out_of_channel_notify(:title => "notify airbrake").should be_nil
   end
 
   it "should notify airbrake" do
     Airbrake.should_receive(:notify).with(UniformNotifier::Exception.new("notify airbrake"))
 
     UniformNotifier.airbrake = true
-    UniformNotifier::AirbrakeNotifier.out_of_channel_notify("notify airbrake")
+    UniformNotifier::AirbrakeNotifier.out_of_channel_notify(:title => "notify airbrake")
   end
 end

--- a/spec/uniform_notifier/base_spec.rb
+++ b/spec/uniform_notifier/base_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe UniformNotifier::Base do
+  context "#inline_channel_notify" do
+    before do
+      UniformNotifier::Base.stub(:active?).and_return(true)
+    end
+    it "should keep the compatibility" do
+      UniformNotifier::Base.should_receive(:_inline_notify).once.with(:title => "something")
+      UniformNotifier::Base.inline_notify("something")
+    end
+  end
+  context "#out_of_channel_notify" do
+    before do
+      UniformNotifier::Base.stub(:active?).and_return(true)
+    end
+    it "should keep the compatibility" do
+      UniformNotifier::Base.should_receive(:_out_of_channel_notify).once.with(:title => "something")
+      UniformNotifier::Base.out_of_channel_notify("something")
+    end
+  end
+end

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -6,13 +6,13 @@ end
 
 describe UniformNotifier::BugsnagNotifier do
   it "should not notify bugsnag" do
-    UniformNotifier::BugsnagNotifier.out_of_channel_notify("notify bugsnag").should be_nil
+    UniformNotifier::BugsnagNotifier.out_of_channel_notify(:title => "notify bugsnag").should be_nil
   end
 
   it "should notify bugsnag" do
     Bugsnag.should_receive(:notify).with(UniformNotifier::Exception.new("notify bugsnag"))
 
     UniformNotifier.bugsnag = true
-    UniformNotifier::BugsnagNotifier.out_of_channel_notify("notify bugsnag")
+    UniformNotifier::BugsnagNotifier.out_of_channel_notify(:title => "notify bugsnag")
   end
 end

--- a/spec/uniform_notifier/customized_logger_spec.rb
+++ b/spec/uniform_notifier/customized_logger_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe UniformNotifier::CustomizedLogger do
   it "should not notify to customized logger" do
-    UniformNotifier::CustomizedLogger.out_of_channel_notify("notify rails logger").should be_nil
+    UniformNotifier::CustomizedLogger.out_of_channel_notify(:title => "notify rails logger").should be_nil
   end
 
   it "should notify to customized logger" do
@@ -12,7 +12,7 @@ describe UniformNotifier::CustomizedLogger do
     now = Time.now
     Time.stub(:now).and_return(now)
     UniformNotifier.customized_logger = logger
-    UniformNotifier::CustomizedLogger.out_of_channel_notify("notify rails logger")
+    UniformNotifier::CustomizedLogger.out_of_channel_notify(:title => "notify rails logger")
 
     logger.seek(0)
     logger.read.should == "#{now.strftime("%Y-%m-%d %H:%M:%S")}[WARN] notify rails logger"

--- a/spec/uniform_notifier/growl_spec.rb
+++ b/spec/uniform_notifier/growl_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe UniformNotifier::Growl do
 
   it "should not notify growl" do
-    UniformNotifier::Growl.out_of_channel_notify('notify growl').should be_nil
+    UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl').should be_nil
   end
 
   it "should notify growl without password" do
@@ -15,7 +15,7 @@ describe UniformNotifier::Growl do
     growl.should_receive(:notify).with('uniform_notifier', 'Uniform Notifier', 'notify growl without password').ordered
 
     UniformNotifier.growl = true
-    UniformNotifier::Growl.out_of_channel_notify('notify growl without password')
+    UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl without password')
   end
 
   it "should notify growl with password" do
@@ -27,7 +27,7 @@ describe UniformNotifier::Growl do
     growl.should_receive(:notify).with('uniform_notifier', 'Uniform Notifier', 'notify growl with password').ordered
 
     UniformNotifier.growl = { :password => '123456' }
-    UniformNotifier::Growl.out_of_channel_notify('notify growl with password')
+    UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl with password')
   end
 
   it "should notify growl with quiet" do
@@ -39,6 +39,6 @@ describe UniformNotifier::Growl do
     growl.should_receive(:notify).with('uniform_notifier', 'Uniform Notifier', 'notify growl with password')
 
     UniformNotifier.growl = { :password => '123456', :quiet => true }
-    UniformNotifier::Growl.out_of_channel_notify('notify growl with password')
+    UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl with password')
   end
 end

--- a/spec/uniform_notifier/javascript_alert_spec.rb
+++ b/spec/uniform_notifier/javascript_alert_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 
 describe UniformNotifier::JavascriptAlert do
   it "should not notify message" do
-    UniformNotifier::JavascriptAlert.inline_notify("javascript alert!").should be_nil
+    UniformNotifier::JavascriptAlert.inline_notify(:title => "javascript alert!").should be_nil
   end
 
   it "should notify message" do
     UniformNotifier.alert = true
-    UniformNotifier::JavascriptAlert.inline_notify("javascript alert!").should == <<-CODE
+    UniformNotifier::JavascriptAlert.inline_notify(:title => "javascript alert!").should == <<-CODE
 <script type="text/javascript">/*<![CDATA[*/
 alert( "javascript alert!" );
 /*]]>*/</script>

--- a/spec/uniform_notifier/javascript_console_spec.rb
+++ b/spec/uniform_notifier/javascript_console_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 
 describe UniformNotifier::JavascriptConsole do
   it "should not notify message" do
-    UniformNotifier::JavascriptConsole.inline_notify("javascript console!").should be_nil
+    UniformNotifier::JavascriptConsole.inline_notify(:title => "javascript console!").should be_nil
   end
 
   it "should notify message" do
     UniformNotifier.console = true
-    UniformNotifier::JavascriptConsole.inline_notify("javascript console!").should == <<-CODE
+    UniformNotifier::JavascriptConsole.inline_notify(:title => "javascript console!").should == <<-CODE
 <script type="text/javascript">/*<![CDATA[*/
 if (typeof(console) !== 'undefined' && console.log) {
   if (console.groupCollapsed && console.groupEnd) {

--- a/spec/uniform_notifier/rails_logger_spec.rb
+++ b/spec/uniform_notifier/rails_logger_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe UniformNotifier::RailsLogger do
   it "should not notify rails logger" do
-    UniformNotifier::RailsLogger.out_of_channel_notify("notify rails logger").should be_nil
+    UniformNotifier::RailsLogger.out_of_channel_notify(:title => "notify rails logger").should be_nil
   end
 
   it "should notify rails logger" do
@@ -15,6 +15,6 @@ describe UniformNotifier::RailsLogger do
     logger.should_receive(:warn).with("notify rails logger")
 
     UniformNotifier.rails_logger = true
-    UniformNotifier::RailsLogger.out_of_channel_notify("notify rails logger")
+    UniformNotifier::RailsLogger.out_of_channel_notify(:title => "notify rails logger")
   end
 end

--- a/spec/uniform_notifier/raise_spec.rb
+++ b/spec/uniform_notifier/raise_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 
 describe UniformNotifier::Raise do
   it "should not notify message" do
-    UniformNotifier::Raise.out_of_channel_notify("notification").should be_nil
+    UniformNotifier::Raise.out_of_channel_notify(:title => "notification").should be_nil
   end
 
   it "should raise error of the default class" do
     UniformNotifier.raise = true
     expect {
-      UniformNotifier::Raise.out_of_channel_notify("notification")
+      UniformNotifier::Raise.out_of_channel_notify(:title => "notification")
     }.to raise_error(UniformNotifier::Exception, "notification")
   end
 
@@ -16,7 +16,7 @@ describe UniformNotifier::Raise do
     klass = Class.new(Exception)
     UniformNotifier.raise = klass
     expect {
-      UniformNotifier::Raise.out_of_channel_notify("notification")
+      UniformNotifier::Raise.out_of_channel_notify(:title => "notification")
     }.to raise_error(klass, "notification")
   end
 
@@ -25,7 +25,7 @@ describe UniformNotifier::Raise do
     UniformNotifier.raise = false
 
     expect {
-      UniformNotifier::Raise.out_of_channel_notify("notification")
+      UniformNotifier::Raise.out_of_channel_notify(:title => "notification")
     }.not_to raise_error
   end
 end

--- a/spec/uniform_notifier/xmpp_spec.rb
+++ b/spec/uniform_notifier/xmpp_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe UniformNotifier::Xmpp do
   it "should not notify xmpp" do
-    UniformNotifier::Xmpp.out_of_channel_notify("notify xmpp").should be_nil
+    UniformNotifier::Xmpp.out_of_channel_notify(:title => "notify xmpp").should be_nil
   end
 
   it "should notify xmpp without online status" do
@@ -20,7 +20,7 @@ describe UniformNotifier::Xmpp do
     xmpp.should_receive(:send).with(message)
 
     UniformNotifier.xmpp = {:account => 'from@gmail.com', :password => '123456', :receiver => 'to@gmail.com', :show_online_status => false}
-    UniformNotifier::Xmpp.out_of_channel_notify('notify xmpp')
+    UniformNotifier::Xmpp.out_of_channel_notify(:title => 'notify xmpp')
   end
 
   it "should notify xmpp with online status" do
@@ -45,6 +45,6 @@ describe UniformNotifier::Xmpp do
     xmpp.should_receive(:send).with(message)
 
     UniformNotifier.xmpp = {:account => 'from@gmail.com', :password => '123456', :receiver => 'to@gmail.com', :show_online_status => true}
-    UniformNotifier::Xmpp.out_of_channel_notify('notify xmpp')
+    UniformNotifier::Xmpp.out_of_channel_notify(:title => 'notify xmpp')
   end
 end


### PR DESCRIPTION
Sorry for the drastically change... I think we can support detail notify data.

``` rb
  UniformNotifier.xxx.out_of_channel_notify(:title => "title", :stacktrace => "something\msomething\n")
```

Handling the detail data as string is up to the notifier. Exception management service can show the backtraces separately from the message.

This change also support the old protocol of passing string.
