### PR TITLE
Delete trailing comma for Ruby 1.8/Rails 2.3 compatibility.

### DIFF
--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -15,7 +15,7 @@ module UniformNotifier
       exception = Exception.new(data[:title])
       Bugsnag.notify(exception, opt.merge(
         :grouping_hash => data[:body] || data[:title],
-        :notification => data,
+        :notification => data
       ))
     end
   end


### PR DESCRIPTION
`bugsnag.rb` causes an error when we try to load `uniform_notifier` in our Rails 2.3 project:

```
=> Booting Mongrel
=> Rails 2.3.18 application starting on http://0.0.0.0:3000
/home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require': /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/uniform_notifier-1.6.1/lib/uniform_notifier/bugsnag.rb:19: syntax error, unexpected ')' (SyntaxError)
      ))
       ^
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:547:in `new_constants_in'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/uniform_notifier-1.6.1/lib/uniform_notifier.rb:10
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:547:in `new_constants_in'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:182:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bullet-4.5.0/lib/bullet.rb:2
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:72:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:72:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:70:in `each'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:70:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:59:in `each'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler/runtime.rb:59:in `require'
        from /home/ahao/.rbenv/versions/ree-1.8.7-2012.02/lib/ruby/gems/1.8/gems/bundler-1.3.5/lib/bundler.rb:132:in `require'
        from /data/apps/blurby/config/boot.rb:121:in `load_environment'
```
