### PR TITLE
 Added host option for growl

### DIFF
--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -20,8 +20,13 @@ module UniformNotifier
     def self.setup_connection_growl( growl )
       return unless growl
       require 'ruby-growl'
-      @password = growl.instance_of?(Hash) ? growl[:password] : nil
-      @growl = ::Growl.new 'localhost', 'uniform_notifier'
+      if growl.instance_of?(Hash)
+        @password = growl.include?(:password) ? growl[:password] : nil
+        @host = growl.include?(:host) ? growl[:host] : 'localhost'
+      end
+      @password ||= nil
+      @host ||= 'localhost'
+      @growl = ::Growl.new @host, 'uniform_notifier'
       @growl.add_notification 'uniform_notifier'
       @growl.password = @password
 
@@ -31,8 +36,13 @@ module UniformNotifier
     def self.setup_connection_gntp( growl )
       return unless growl
       require 'ruby_gntp'
-      @password = growl.instance_of?(Hash) ? growl[:password] : nil
-      @growl = GNTP.new('uniform_notifier', 'localhost', @password, 23053)
+      if growl.instance_of?(Hash)
+        @password = growl.include?(:password) ? growl[:password] : nil
+        @host = growl.include?(:host) ? growl[:host] : 'localhost'
+      end
+      @password ||= nil
+      @host ||= 'localhost'
+      @growl = GNTP.new('uniform_notifier', @host, @password, 23053)
       @growl.register({:notifications => [{
                                             :name     => 'uniform_notifier',
                                             :enabled  => true,

--- a/spec/uniform_notifier/growl_spec.rb
+++ b/spec/uniform_notifier/growl_spec.rb
@@ -30,6 +30,18 @@ describe UniformNotifier::Growl do
     UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl with password')
   end
 
+  it "should notify growl with host" do
+    growl = double('growl', :is_a? => true)
+    Growl.should_receive(:new).with('10.10.156.17', 'uniform_notifier').and_return(growl)
+    growl.should_receive(:add_notification).with('uniform_notifier')
+    growl.should_receive(:password=).with('123456')
+    growl.should_receive(:notify).with('uniform_notifier', 'Uniform Notifier', 'Uniform Notifier Growl has been turned on').ordered
+    growl.should_receive(:notify).with('uniform_notifier', 'Uniform Notifier', 'notify growl with password').ordered
+
+    UniformNotifier.growl = { :password => '123456', :host => '10.10.156.17' }
+    UniformNotifier::Growl.out_of_channel_notify(:title => 'notify growl with password')
+  end
+
   it "should notify growl with quiet" do
     growl = double('growl', :is_a? => true)
     Growl.should_receive(:new).with('localhost', 'uniform_notifier').and_return(growl)


### PR DESCRIPTION
Added host option to Growl notifications. Tested with ruby_gntp and works. ruby-growl hangs on notify but I do not know if it's problem with my client or so (I am using Snarl).