### PR TITLE
Add integration with rollbar-gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ if you want to notify by airbrake, you should install airbrake first
 
     gem install airbrake
 
+if you want to notify by rollbar, you should install rollbar first
+
+    gem install rollbar
+
 if you want to notify by bugsnag, you should install bugsnag first
 
     gem install bugsnag
@@ -59,6 +63,9 @@ By default, all notifiers are disabled, you should enable them first.
     UniformNotifier.airbrake = true
     # airbrake with options
     UniformNotifier.airbrake = { :error_class => Exception }
+
+    # rollbar
+    UniformNotifier.rollbar = true
 
     # bugsnag
     UniformNotifier.bugsnag = true

--- a/lib/uniform_notifier.rb
+++ b/lib/uniform_notifier.rb
@@ -7,6 +7,7 @@ require 'uniform_notifier/xmpp'
 require 'uniform_notifier/rails_logger'
 require 'uniform_notifier/customized_logger'
 require 'uniform_notifier/airbrake'
+require 'uniform_notifier/rollbar'
 require 'uniform_notifier/bugsnag'
 require 'uniform_notifier/slack'
 require 'uniform_notifier/raise'
@@ -15,7 +16,7 @@ module UniformNotifier
   class NotificationError < StandardError; end
 
   class <<self
-    attr_accessor :alert, :console, :growl, :rails_logger, :xmpp, :airbrake, :bugsnag, :slack, :raise
+    attr_accessor :alert, :console, :growl, :rails_logger, :xmpp, :airbrake, :rollbar, :bugsnag, :slack, :raise
 
     NOTIFIERS = [JavascriptAlert, JavascriptConsole, Growl, Xmpp, RailsLogger, CustomizedLogger, AirbrakeNotifier, BugsnagNotifier, Raise, Slack]
 

--- a/lib/uniform_notifier/rollbar.rb
+++ b/lib/uniform_notifier/rollbar.rb
@@ -1,0 +1,16 @@
+module UniformNotifier
+  class RollbarNotifier < Base
+    def self.active?
+      !!UniformNotifier.rollbar
+    end
+
+    protected
+
+    def self._out_of_channel_notify(data)
+      message = data.values.compact.join("\n")
+
+      exception = Exception.new(message)
+      Rollbar.info(exception)
+    end
+  end
+end

--- a/spec/uniform_notifier/rollbar_spec.rb
+++ b/spec/uniform_notifier/rollbar_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+class Rollbar
+  # mock Rollbar
+end
+
+describe UniformNotifier::RollbarNotifier do
+  it "should not notify rollbar" do
+    UniformNotifier::RollbarNotifier.out_of_channel_notify(:title => "notify rollbar").should be_nil
+  end
+
+  it "should notify rollbar" do
+    Rollbar.should_receive(:info).with(UniformNotifier::Exception.new("notify rollbar"))
+
+    UniformNotifier.rollbar = true
+    UniformNotifier::RollbarNotifier.out_of_channel_notify(:title => "notify rollbar")
+  end
+end


### PR DESCRIPTION
Hi. 
We started using your gem and faced with a kind of problem that uniform_notifier does not support Rollbar. 
Please look at this PR and let me know if something is wrong.
BTW, i thought about setting notification level in configuration something like this: `UniformNotifier.rollbar = {log_level: 'warning'}` but using 'info' by default. What do you think?