### PR TITLE
Set correct backtrace

### DIFF
--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -13,6 +13,7 @@ module UniformNotifier
       end
 
       exception = Exception.new(data[:title])
+      exception.set_backtrace(data[:backtrace]) if data[:backtrace]
       Bugsnag.notify(exception, opt.merge(
         :grouping_hash => data[:body] || data[:title],
         :notification => data

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -44,4 +44,13 @@ describe UniformNotifier::BugsnagNotifier do
       UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
     end
   end
+
+  it "should notify bugsnag with correct backtrace" do
+    Bugsnag.should_receive(:notify) do |error|
+      error.should be_a UniformNotifier::Exception
+      error.backtrace.should eq ["bugsnag spec test"]
+    end
+    UniformNotifier.bugsnag = true
+    UniformNotifier::BugsnagNotifier.out_of_channel_notify(backtrace: ["bugsnag spec test"])
+  end
 end


### PR DESCRIPTION
I think we should set correct backtrace in the exception to notify Bugsnag.

![bugsnag](https://cloud.githubusercontent.com/assets/1162120/6776898/bbfccc18-d187-11e4-90ca-d65dcb4a4d27.png)

I also send PR to bullet gem.
https://github.com/flyerhzm/bullet/pull/218

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/flyerhzm/uniform_notifier/28)
<!-- Reviewable:end -->
