### PR TITLE
Add license flag to the gemspec

### DIFF
--- a/uniform_notifier.gemspec
+++ b/uniform_notifier.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://rubygems.org/gems/uniform_notifier"
   s.summary     = %q{uniform notifier for rails logger, customized logger, javascript alert, javascript console, growl and xmpp}
   s.description = %q{uniform notifier for rails logger, customized logger, javascript alert, javascript console, growl and xmpp}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "uniform_notifier"
 


### PR DESCRIPTION
I picked the MIT license, as the LICENSE file looks like MIT.
I would like to add this because it will make automated license checking using [dblock/gem-license](https://github.com/dblock/gem-licenses) easier.