### PR TITLE
⚠️ Ruby warnings

### DIFF
--- a/lib/uniform_notifier.rb
+++ b/lib/uniform_notifier.rb
@@ -23,7 +23,7 @@ class UniformNotifier
   class NotificationError < StandardError; end
 
   class <<self
-    attr_accessor *AVAILABLE_NOTIFIERS
+    attr_accessor(*AVAILABLE_NOTIFIERS)
 
     def active_notifiers
       NOTIFIERS.select { |notifier| notifier.active? }

--- a/lib/uniform_notifier.rb
+++ b/lib/uniform_notifier.rb
@@ -29,22 +29,27 @@ class UniformNotifier
       NOTIFIERS.select { |notifier| notifier.active? }
     end
 
+    undef :growl=
     def growl=(growl)
       UniformNotifier::Growl.setup_connection(growl)
     end
 
+    undef :xmpp=
     def xmpp=(xmpp)
       UniformNotifier::Xmpp.setup_connection(xmpp)
     end
 
+    undef :customized_logger=
     def customized_logger=(logdev)
       UniformNotifier::CustomizedLogger.setup(logdev)
     end
 
+    undef :slack=
     def slack=(slack)
       UniformNotifier::Slack.setup_connection(slack)
     end
 
+    undef :raise=
     def raise=(exception_class)
       UniformNotifier::Raise.setup_connection(exception_class)
     end

--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -71,5 +71,5 @@ class UniformNotifier
                         })
         end
       end
-    end
   end
+end


### PR DESCRIPTION
Here's an attempt to eliminate Ruby warnings.

TBH I don't really like the `undef`s against method redefinition, but I couldn't come up with a better code.