### PR TITLE
Allow custom attributes to be set on javascript script tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ By default, all notifiers are disabled, you should enable them first.
 
     # javascript alert
     UniformNotifier.alert = true
+    # javascript alert with options
+    # the attributes key adds custom attributes to the script tag appended to the body
+    UniformNotifier.alert = { :attributes => { :nonce => 'mySecret-nonce', 'data-key' => 'value' } }
 
     # javascript console (Safari/Webkit browsers or Firefox w/Firebug installed)
     UniformNotifier.console = true
+    # javascript console with options
+    # the attributes key adds custom attributes to the script tag appended to the body
+    UniformNotifier.console = { :attributes => { :nonce => 'mySecret-nonce', 'data-key' => 'value' } }
 
     # rails logger
     UniformNotifier.rails_logger = true

--- a/lib/uniform_notifier/base.rb
+++ b/lib/uniform_notifier/base.rb
@@ -30,9 +30,12 @@ class UniformNotifier
     def self._out_of_channel_notify( data )
     end
 
-    def self.wrap_js_association( code )
+    def self.wrap_js_association( code, attributes = {} )
+      attributes = {type: 'text/javascript'}.merge(attributes || {})
+      attributes_string = attributes.map { |k, v| "#{k}=#{v.to_s.inspect}" }.join(' ')
+
       <<-CODE
-<script type="text/javascript">/*<![CDATA[*/
+<script #{attributes_string}>/*<![CDATA[*/
 #{code}
 /*]]>*/</script>
       CODE

--- a/lib/uniform_notifier/javascript_alert.rb
+++ b/lib/uniform_notifier/javascript_alert.rb
@@ -1,15 +1,17 @@
 class UniformNotifier
   class JavascriptAlert < Base
     def self.active?
-      UniformNotifier.alert
+      !!UniformNotifier.alert
     end
 
     protected
 
     def self._inline_notify( data )
       message = data.values.compact.join("\n")
+      options = UniformNotifier.alert.is_a?(Hash) ? UniformNotifier.alert : {}
+      script_attributes = options[:attributes] || {}
 
-      wrap_js_association "alert( #{message.inspect} );"
+      wrap_js_association "alert( #{message.inspect} );", script_attributes
     end
   end
 end

--- a/lib/uniform_notifier/javascript_console.rb
+++ b/lib/uniform_notifier/javascript_console.rb
@@ -1,13 +1,15 @@
 class UniformNotifier
   class JavascriptConsole < Base
     def self.active?
-      UniformNotifier.console
+      !!UniformNotifier.console
     end
 
     protected
 
     def self._inline_notify( data )
       message = data.values.compact.join("\n")
+      options = UniformNotifier.console.is_a?(Hash) ? UniformNotifier.console : {}
+      script_attributes = options[:attributes] || {}
 
       code = <<-CODE
 if (typeof(console) !== 'undefined' && console.log) {
@@ -21,7 +23,7 @@ if (typeof(console) !== 'undefined' && console.log) {
 }
 CODE
 
-      wrap_js_association code
+      wrap_js_association code, script_attributes
     end
   end
 end

--- a/spec/uniform_notifier/javascript_alert_spec.rb
+++ b/spec/uniform_notifier/javascript_alert_spec.rb
@@ -13,4 +13,22 @@ alert( "javascript alert!" );
 /*]]>*/</script>
 CODE
   end
+
+  it "should accept custom attributes" do
+    UniformNotifier.alert = { attributes: { nonce: 'my-nonce', 'data-key' => :value } }
+    expect(UniformNotifier::JavascriptAlert.inline_notify(:title => "javascript alert!")).to eq <<-CODE
+<script type="text/javascript" nonce="my-nonce" data-key="value">/*<![CDATA[*/
+alert( "javascript alert!" );
+/*]]>*/</script>
+CODE
+  end
+
+  it "should have default attributes if no attributes settings exist" do
+    UniformNotifier.alert = {}
+    expect(UniformNotifier::JavascriptAlert.inline_notify(:title => "javascript alert!")).to eq <<-CODE
+<script type="text/javascript">/*<![CDATA[*/
+alert( "javascript alert!" );
+/*]]>*/</script>
+    CODE
+  end
 end

--- a/spec/uniform_notifier/javascript_console_spec.rb
+++ b/spec/uniform_notifier/javascript_console_spec.rb
@@ -22,4 +22,40 @@ if (typeof(console) !== 'undefined' && console.log) {
 /*]]>*/</script>
     CODE
   end
+
+  it "should accept custom attributes" do
+    UniformNotifier.console = { attributes: { nonce: 'my-nonce', 'data-key' => :value } }
+    expect(UniformNotifier::JavascriptConsole.inline_notify(:title => "javascript console!")).to eq <<-CODE
+<script type="text/javascript" nonce="my-nonce" data-key="value">/*<![CDATA[*/
+if (typeof(console) !== 'undefined' && console.log) {
+  if (console.groupCollapsed && console.groupEnd) {
+    console.groupCollapsed(#{"Uniform Notifier".inspect});
+    console.log(#{"javascript console!".inspect});
+    console.groupEnd();
+  } else {
+    console.log(#{"javascript console!".inspect});
+  }
+}
+
+/*]]>*/</script>
+    CODE
+  end
+
+  it "should have default attributes if no attributes settings exist" do
+    UniformNotifier.console = {}
+    expect(UniformNotifier::JavascriptConsole.inline_notify(:title => "javascript console!")).to eq <<-CODE
+<script type="text/javascript">/*<![CDATA[*/
+if (typeof(console) !== 'undefined' && console.log) {
+  if (console.groupCollapsed && console.groupEnd) {
+    console.groupCollapsed(#{"Uniform Notifier".inspect});
+    console.log(#{"javascript console!".inspect});
+    console.groupEnd();
+  } else {
+    console.log(#{"javascript console!".inspect});
+  }
+}
+
+/*]]>*/</script>
+    CODE
+  end
 end


### PR DESCRIPTION
As part of CSP for our website, we enforce nonces on inline scripts. Using bullet in development causes a lot of CSP errors. We define and allow a specific static nonce to be used only in development mode, and by putting the nonce on the script tags added by bullet we can remove the CSP errors.

This PR adds the ability to provide custom attributes to the inline script tags added by the `console` and `alert` notifiers.