### PR TITLE
Require Ruby 2.3+ in gemspec

### DIFF
--- a/uniform_notifier.gemspec
+++ b/uniform_notifier.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'uniform_notifier'
 
+  s.required_ruby_version = '>= 2.3'
+
   s.add_development_dependency 'ruby-growl', ['= 4.0']
   s.add_development_dependency 'ruby_gntp', ['= 0.3.4']
   s.add_development_dependency 'xmpp4r', ['= 0.5']


### PR DESCRIPTION
This https://github.com/flyerhzm/uniform_notifier/commit/685f381ed5dbb30e54ce18062c322725372bf022 commit broke the gem for Ruby 2.2 and below, as "squiggly heredoc" was added only in Ruby 2.3.

I'm aware Ruby 2.2 is EOL but it may brake people's projects (it broke one of mine). 