### PR TITLE
Auto corrected by following Lint Ruby TrailingComma

### DIFF
--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -47,7 +47,7 @@ class UniformNotifier
       @growl = GNTP.new('uniform_notifier', @host, @password, 23053)
       @growl.register(notifications: [{
                         name: 'uniform_notifier',
-                        enabled: true,
+                        enabled: true
                       }])
 
       notify 'Uniform Notifier Growl has been turned on (using GNTP)' if !growl.instance_of?(Hash) || !growl[:quiet]


### PR DESCRIPTION
Auto corrected by following Lint Ruby TrailingComma

Click [here](https://awesomecode.io/repos/flyerhzm/uniform_notifier/ruby_config_groups/924) to configure it on awesomecode.io