### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/uniform_notifier/growl.rb
+++ b/lib/uniform_notifier/growl.rb
@@ -21,6 +21,7 @@ class UniformNotifier
 
     def self.setup_connection_growl(growl)
       return unless growl
+
       require 'ruby-growl'
       if growl.instance_of?(Hash)
         @password = growl.include?(:password) ? growl[:password] : nil
@@ -37,6 +38,7 @@ class UniformNotifier
 
     def self.setup_connection_gntp(growl)
       return unless growl
+
       require 'ruby_gntp'
       if growl.instance_of?(Hash)
         @password = growl.include?(:password) ? growl[:password] : nil


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io//repos/flyerhzm/uniform_notifier/ruby_config_groups/347) to configure it on awesomecode.io