### PR TITLE
Fix UniformNotifier::Raise.active? when .rails= receives a false value

### DIFF
--- a/lib/uniform_notifier/raise.rb
+++ b/lib/uniform_notifier/raise.rb
@@ -3,7 +3,7 @@
 class UniformNotifier
   class Raise < Base
     def self.active?
-      defined?(@exception_class)
+      defined?(@exception_class) ? @exception_class : false
     end
 
     def self.setup_connection(exception_class)


### PR DESCRIPTION
on 1.13.1, Test fails as belows.

```
  1) UniformNotifier::Raise can be turned from on to off again
     Failure/Error: expect { UniformNotifier::Raise.out_of_channel_notify(title: 'notification') }.not_to raise_error

       expected no Exception, got #<TypeError: exception class/object expected> with backtrace:
         # ./lib/uniform_notifier/raise.rb:18:in `raise'
         # ./lib/uniform_notifier/raise.rb:18:in `_out_of_channel_notify'
         # ./lib/uniform_notifier/base.rb:24:in `out_of_channel_notify'
         # ./spec/uniform_notifier/raise_spec.rb:28:in `block (3 levels) in <top (required)>'
         # ./spec/uniform_notifier/raise_spec.rb:28:in `block (2 levels) in <top (required)>'
     # ./spec/uniform_notifier/raise_spec.rb:28:in `block (2 levels) in <top (required)>'
```

This is a lack of consideration when .raise= receives a false value