### PR TITLE
Fix uninitialized constant UniformNotifier::SentryNotifier::Raven error

### DIFF
--- a/lib/uniform_notifier/sentry.rb
+++ b/lib/uniform_notifier/sentry.rb
@@ -15,7 +15,7 @@ class UniformNotifier
       opt = UniformNotifier.sentry if UniformNotifier.sentry.is_a?(Hash)
 
       exception = Exception.new(message)
-      Raven.capture_exception(exception, opt)
+      Sentry.capture_exception(exception, opt)
     end
   end
 end

--- a/spec/uniform_notifier/sentry_spec.rb
+++ b/spec/uniform_notifier/sentry_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-class Raven
+class Sentry
   # mock Sentry
 end
 
@@ -12,14 +12,14 @@ RSpec.describe UniformNotifier::SentryNotifier do
   end
 
   it 'should notify sentry' do
-    expect(Raven).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), {})
+    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), {})
 
     UniformNotifier.sentry = true
     UniformNotifier::SentryNotifier.out_of_channel_notify(title: 'notify sentry')
   end
 
   it 'should notify sentry' do
-    expect(Raven).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), foo: :bar)
+    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), foo: :bar)
 
     UniformNotifier.sentry = { foo: :bar }
     UniformNotifier::SentryNotifier.out_of_channel_notify('notify sentry')


### PR DESCRIPTION
Fixes `uninitialized constant UniformNotifier::SentryNotifier::Raven` error which also described in https://github.com/flyerhzm/bullet/issues/543#issue-785873499