### PR TITLE
Fix capture_exception signature

### DIFF
--- a/lib/uniform_notifier/sentry.rb
+++ b/lib/uniform_notifier/sentry.rb
@@ -16,7 +16,7 @@ class UniformNotifier
         opt = UniformNotifier.sentry if UniformNotifier.sentry.is_a?(Hash)
 
         exception = Exception.new(message)
-        Sentry.capture_exception(exception, opt)
+        Sentry.capture_exception(exception, **opt)
       end
     end
   end

--- a/spec/uniform_notifier/sentry_spec.rb
+++ b/spec/uniform_notifier/sentry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UniformNotifier::SentryNotifier do
   end
 
   it 'should notify sentry' do
-    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), {})
+    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'))
 
     UniformNotifier.sentry = true
     UniformNotifier::SentryNotifier.out_of_channel_notify(title: 'notify sentry')


### PR DESCRIPTION
Seems like capture_exception method signature has been changed. I didn't realize that.

Sorry for the inconvenience. Fixed now.