### PR TITLE
Fix sentry spec for ruby < 3.0

### DIFF
--- a/spec/uniform_notifier/sentry_spec.rb
+++ b/spec/uniform_notifier/sentry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UniformNotifier::SentryNotifier do
   end
 
   it 'should notify sentry' do
-    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'))
+    expect(Sentry).to receive(:capture_exception).with(UniformNotifier::Exception.new('notify sentry'), {})
 
     UniformNotifier.sentry = true
     UniformNotifier::SentryNotifier.out_of_channel_notify(title: 'notify sentry')


### PR DESCRIPTION
It's really odd that I have Ruby v3.0 and all specs are green but Travis CI failed. I've checked with v2.6 and spec is red.

Really odd. This PR spec red in Ruby v3.0 but green in < v3.0 now.

Sorry.