### PR TITLE
Fix : Bugsnag report configuration

### DIFF
--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -10,12 +10,20 @@ class UniformNotifier
       protected
 
       def _out_of_channel_notify(data)
-        opt = {}
-        opt = UniformNotifier.bugsnag if UniformNotifier.bugsnag.is_a?(Hash)
-
         exception = Exception.new(data[:title])
         exception.set_backtrace(data[:backtrace]) if data[:backtrace]
-        Bugsnag.notify(exception, opt.merge(grouping_hash: data[:body] || data[:title], notification: data))
+
+        return nil if data.empty?
+
+        Bugsnag.notify(exception) do |report|
+          report.severity = "warning"
+          report.add_tab(:bullet, data)
+          report.grouping_hash = data[:body] || data[:title]
+
+          if UniformNotifier.bugsnag.is_a?(Proc)
+            UniformNotifier.bugsnag.call(report)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Hello,

The notifier for bugsnag still uses a deprecated, and now unsupported way of report configuration, which is by passing in a hash. This causes the reports sent to bugsnag to not be configured properly (grouping hashes are not taken into account, the corresponding data neither).

I have made a fix to use the up-to-date signature for bugsnag which takes a block for report configuration. The behaviour of the code is preserved as much as possible, to correspond with the existing. Tests were also modified to correspond.