### PR TITLE
Improve appsignal message

### DIFF
--- a/lib/uniform_notifier/appsignal.rb
+++ b/lib/uniform_notifier/appsignal.rb
@@ -12,7 +12,7 @@ class UniformNotifier
       def _out_of_channel_notify(data)
         opt = UniformNotifier.appsignal.is_a?(Hash) ? UniformNotifier.appsignal : {}
 
-        exception = Exception.new(data[:title])
+        exception = Exception.new("#{data[:title]}\n#{data[:body]}")
         exception.set_backtrace(data[:backtrace]) if data[:backtrace]
 
         tags = opt.fetch(:tags, {}).merge(data.fetch(:tags, {}))

--- a/lib/uniform_notifier/appsignal.rb
+++ b/lib/uniform_notifier/appsignal.rb
@@ -18,7 +18,10 @@ class UniformNotifier
         tags = opt.fetch(:tags, {}).merge(data.fetch(:tags, {}))
         namespace = data[:namespace] || opt[:namespace]
 
-        Appsignal.send_error(*[exception, tags, namespace].compact)
+        Appsignal.send_error(exception) do |transaction|
+          transaction.set_tags(tags)
+          transaction.set_namespace(namespace)
+        end
       end
     end
   end

--- a/spec/uniform_notifier/appsignal_spec.rb
+++ b/spec/uniform_notifier/appsignal_spec.rb
@@ -12,39 +12,50 @@ RSpec.describe UniformNotifier::AppsignalNotifier do
   end
 
   it 'should notify appsignal with keyword title' do
-    expect(Appsignal).to receive(:send_error).with(UniformNotifier::Exception.new('notify appsignal'), {})
+    expect(Appsignal).to receive(:send_error).with(UniformNotifier::Exception.new("notify appsignal\n"))
 
     UniformNotifier.appsignal = true
     expect(UniformNotifier::AppsignalNotifier.out_of_channel_notify(title: 'notify appsignal'))
   end
 
   it 'should notify appsignal with first argument title' do
-    expect(Appsignal).to receive(:send_error).with(UniformNotifier::Exception.new('notify appsignal'), {})
+    expect(Appsignal).to receive(:send_error).with(
+      UniformNotifier::Exception.new("notify appsignal\n")
+    )
 
     UniformNotifier.appsignal = true
     UniformNotifier::AppsignalNotifier.out_of_channel_notify('notify appsignal')
   end
 
   it 'should notify appsignal with tags' do
-    expect(Appsignal).to receive(:send_error).with(UniformNotifier::Exception.new('notify appsignal'), { foo: :bar })
+    transaction = double('Appsignal::Transaction', set_namespace: nil)
+    expect(transaction).to receive(:set_tags).with({ foo: :bar })
+    expect(Appsignal).to receive(:send_error).with(
+      UniformNotifier::Exception.new("notify appsignal\n")
+    ).and_yield(transaction)
 
     UniformNotifier.appsignal = true
     UniformNotifier::AppsignalNotifier.out_of_channel_notify(title: 'notify appsignal', tags: { foo: :bar })
   end
 
   it 'should notify appsignal with default namespace' do
-    expect(Appsignal).to receive(:send_error).with(UniformNotifier::Exception.new('notify appsignal'), {}, 'web')
+    transaction = double('Appsignal::Transaction', set_tags: nil)
+    expect(transaction).to receive(:set_namespace).with('web')
+    expect(Appsignal).to receive(:send_error).with(
+      UniformNotifier::Exception.new("notify appsignal\n")
+    ).and_yield(transaction)
 
     UniformNotifier.appsignal = { namespace: 'web' }
     UniformNotifier::AppsignalNotifier.out_of_channel_notify('notify appsignal')
   end
 
   it 'should notify appsignal with overridden namespace' do
+    transaction = double('Appsignal::Transaction')
+    expect(transaction).to receive(:set_tags).with({ foo: :bar })
+    expect(transaction).to receive(:set_namespace).with('background')
     expect(Appsignal).to receive(:send_error).with(
-      UniformNotifier::Exception.new('notify appsignal'),
-      { foo: :bar },
-      'background'
-    )
+      UniformNotifier::Exception.new("notify appsignal\nbody")
+    ).and_yield(transaction)
 
     UniformNotifier.appsignal = { namespace: 'web' }
     UniformNotifier::AppsignalNotifier.out_of_channel_notify(
@@ -52,16 +63,18 @@ RSpec.describe UniformNotifier::AppsignalNotifier do
       tags: {
         foo: :bar
       },
-      namespace: 'background'
+      namespace: 'background',
+      body: 'body',
     )
   end
 
   it 'should notify appsignal with merged tags' do
+    transaction = double('Appsignal::Transaction')
+    expect(transaction).to receive(:set_tags).with({ user: 'Bob', hostname: 'frontend2', site: 'first' })
+    expect(transaction).to receive(:set_namespace).with('background')
     expect(Appsignal).to receive(:send_error).with(
-      UniformNotifier::Exception.new('notify appsignal'),
-      { user: 'Bob', hostname: 'frontend2', site: 'first' },
-      'background'
-    )
+      UniformNotifier::Exception.new("notify appsignal\nbody")
+    ).and_yield(transaction)
 
     UniformNotifier.appsignal = { namespace: 'web', tags: { hostname: 'frontend1', user: 'Bob' } }
     UniformNotifier::AppsignalNotifier.out_of_channel_notify(
@@ -70,6 +83,7 @@ RSpec.describe UniformNotifier::AppsignalNotifier do
         hostname: 'frontend2',
         site: 'first'
       },
+      body: 'body',
       namespace: 'background'
     )
   end


### PR DESCRIPTION
I noticed that error messages on Appsignal are using a deprecated version of the API:

```
appsignal WARNING: The tags argument for `Appsignal.send_error` is deprecated. Please use the block method to set tags instead.

  Appsignal.send_error(error) do |transaction|
    transaction.set_tags({})
  end
```

And I also noticed that the error body is not sent to Appsignal:

<img width="871" alt="image" src="https://user-images.githubusercontent.com/302303/127051489-8161e84b-6ea9-4948-a5a5-99a852ecf0f9.png">


I changed Appsignal class to use the new interface and also to add the body:

<img width="870" alt="image" src="https://user-images.githubusercontent.com/302303/127051560-11f2ebd4-52fc-43d7-90e2-5d7a5be8eb3e.png">
