### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.7
+          - '3.0'
+          - 3.1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in uniform_notifier.gemspec
 gemspec
 
 gem 'rake'
+gem 'rexml' # for Ruby 3.0+

--- a/spec/uniform_notifier/airbrake_spec.rb
+++ b/spec/uniform_notifier/airbrake_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UniformNotifier::AirbrakeNotifier do
   end
 
   it 'should notify airbrake' do
-    expect(Airbrake).to receive(:notify).with(UniformNotifier::Exception.new('notify airbrake'), foo: :bar)
+    expect(Airbrake).to receive(:notify).with(UniformNotifier::Exception.new('notify airbrake'), { foo: :bar })
 
     UniformNotifier.airbrake = { foo: :bar }
     UniformNotifier::AirbrakeNotifier.out_of_channel_notify('notify airbrake')

--- a/spec/uniform_notifier/base_spec.rb
+++ b/spec/uniform_notifier/base_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe UniformNotifier::Base do
   context '#inline_channel_notify' do
     before { allow(UniformNotifier::Base).to receive(:active?).and_return(true) }
     it 'should keep the compatibility' do
-      expect(UniformNotifier::Base).to receive(:_inline_notify).once.with(title: 'something')
+      expect(UniformNotifier::Base).to receive(:_inline_notify).once.with({ title: 'something' })
       UniformNotifier::Base.inline_notify('something')
     end
   end
   context '#out_of_channel_notify' do
     before { allow(UniformNotifier::Base).to receive(:active?).and_return(true) }
     it 'should keep the compatibility' do
-      expect(UniformNotifier::Base).to receive(:_out_of_channel_notify).once.with(title: 'something')
+      expect(UniformNotifier::Base).to receive(:_out_of_channel_notify).once.with({ title: 'something' })
       UniformNotifier::Base.out_of_channel_notify('something')
     end
   end

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
         UniformNotifier::Exception.new(notification_data)
       ).and_yield(report)
       expect(report).to receive(:severity=).with('warning')
-      expect(report).to receive(:add_tab).with(:bullet, title: notification_data)
+      expect(report).to receive(:add_tab).with(:bullet, { title: notification_data })
       expect(report).to receive(:grouping_hash=).with(notification_data)
 
       UniformNotifier.bugsnag = true
@@ -37,7 +37,7 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
       expect(Bugsnag).to receive(:notify).with(
         UniformNotifier::Exception.new(notification_data)
       ).and_yield(report)
-      expect(report).to receive(:meta_data=).with(foo: :bar)
+      expect(report).to receive(:meta_data=).with({ foo: :bar })
 
       UniformNotifier.bugsnag = ->(report) { report.meta_data = { foo: :bar } }
       UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
@@ -62,7 +62,7 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
       expect(Bugsnag).to receive(:notify).with(
         UniformNotifier::Exception.new(notification_data[:title])
       ).and_yield(report)
-      expect(report).to receive(:meta_data=).with(foo: :bar)
+      expect(report).to receive(:meta_data=).with({ foo: :bar })
 
       UniformNotifier.bugsnag = ->(report) { report.meta_data = { foo: :bar } }
       UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)

--- a/spec/uniform_notifier/honeybadger_spec.rb
+++ b/spec/uniform_notifier/honeybadger_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UniformNotifier::HoneybadgerNotifier do
   end
 
   it 'should notify honeybadger' do
-    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'), foo: :bar)
+    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'), { foo: :bar })
 
     UniformNotifier.honeybadger = { foo: :bar }
     UniformNotifier::HoneybadgerNotifier.out_of_channel_notify('notify honeybadger')

--- a/spec/uniform_notifier/slack_spec.rb
+++ b/spec/uniform_notifier/slack_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UniformNotifier::Slack do
 
     it 'should allow username and channel config options' do
       expect(Slack::Notifier).to receive(:new)
-        .with('http://some.slack.url', username: 'The Dude', channel: '#carpets')
+        .with('http://some.slack.url', { username: 'The Dude', channel: '#carpets' })
         .and_return(true)
       UniformNotifier.slack = { webhook_url: 'http://some.slack.url', username: 'The Dude', channel: '#carpets' }
       expect(UniformNotifier::Slack.active?).to eq true


### PR DESCRIPTION
Since June 15th, 2021, the building on travis-ci.org is ceased.
So this PR adds GitHub Actions workflow.
Here are the details:
- Add Ruby 3.0 and 3.1 to the CI matrix
  - CI with Ruby 3.1 fails due to [ruby-growl](https://github.com/drbrain/ruby-growl).
    As mentioned in #58, we should drop the use of it.
- Add `rexml` to Gemfile for Ruby 3.0+
  - `rexml` is a bundled gem from Ruby 3.0.
    Please see https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/ for more info.
- Address CI failure in Ruby 3.0+ 
  - Since `rspec-mocks` v3.10.3, `#with` now distinguishes between keyword args and hash in Ruby 3.
    See rspec/rspec-mocks#1394 for details.