### PR TITLE
Auto corrected by following Lint Ruby Gemspec/RequireMFA

### DIFF
--- a/uniform_notifier.gemspec
+++ b/uniform_notifier.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
     s.metadata['source_code_uri'] = 'https://github.com/flyerhzm/uniform_notifier'
     s.metadata['bug_tracker_uri'] = 'https://github.com/flyerhzm/uniform_notifier/issues'
   end
+s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Gemspec/RequireMFA

Click [here](https://awesomecode.io/repos/flyerhzm/uniform_notifier/lint_configs/ruby/126958) to configure it on awesomecode.io