### PR TITLE
Fixed to run CI with Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         ruby:
           - 2.7
-          - 3.0
+          - '3.0'
           - 3.1
     steps:
       - name: Checkout code


### PR DESCRIPTION
Using 3.0 without quotes, ruby/setup-ruby will use 3.1 instead of 3.0.
Please see https://github.com/ruby/setup-ruby/issues/252 for more details.

And thanks for releasing the new version!