### PR TITLE
Introduce OpenTelemetry notifier

### DIFF
--- a/lib/uniform_notifier.rb
+++ b/lib/uniform_notifier.rb
@@ -16,6 +16,7 @@ require 'uniform_notifier/appsignal'
 require 'uniform_notifier/slack'
 require 'uniform_notifier/raise'
 require 'uniform_notifier/terminal_notifier'
+require 'uniform_notifier/opentelemetry'
 
 class UniformNotifier
   AVAILABLE_NOTIFIERS = %i[
@@ -33,6 +34,7 @@ class UniformNotifier
     sentry
     appsignal
     terminal_notifier
+    opentelemetry
   ].freeze
 
   NOTIFIERS = [
@@ -49,7 +51,8 @@ class UniformNotifier
     Slack,
     SentryNotifier,
     AppsignalNotifier,
-    TerminalNotifier
+    TerminalNotifier,
+    OpenTelemetryNotifier
   ].freeze
 
   class NotificationError < StandardError

--- a/lib/uniform_notifier/opentelemetry.rb
+++ b/lib/uniform_notifier/opentelemetry.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UniformNotifier
+  class OpenTelemetryNotifier < Base
+    class << self
+      def active?
+        !!UniformNotifier.opentelemetry
+      end
+
+      protected
+
+      def _out_of_channel_notify(data)
+        message = data.values.compact.join("\n")
+
+        exception = Exception.new(message)
+        current_span = OpenTelemetry::Trace.current_span
+        current_span.record_exception(exception)
+      end
+    end
+  end
+end

--- a/spec/uniform_notifier/opentelemetry_spec.rb
+++ b/spec/uniform_notifier/opentelemetry_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class OpenTelemetry
+  class Trace
+    # mock OpenTelemetry
+  end
+end
+
+RSpec.describe UniformNotifier::OpenTelemetryNotifier do
+  it 'should not notify OpenTelemetry' do
+    expect(UniformNotifier::OpenTelemetryNotifier.out_of_channel_notify(title: 'notify otel')).to be_nil
+  end
+
+  it 'should notify OpenTelemetry' do
+    span = double('span')
+    expect(span).to receive(:record_exception)
+      .with(UniformNotifier::Exception.new('notify otel'))
+    expect(OpenTelemetry::Trace).to receive(:current_span)
+      .and_return(span)
+
+    UniformNotifier.opentelemetry = true
+    UniformNotifier::OpenTelemetryNotifier.out_of_channel_notify(title: 'notify otel')
+  end
+
+  it 'should notify OpenTelemetry' do
+    span = double('span')
+    expect(span).to receive(:record_exception)
+      .with(UniformNotifier::Exception.new('notify otel'))
+    expect(OpenTelemetry::Trace).to receive(:current_span)
+      .and_return(span)
+
+    UniformNotifier.opentelemetry = { foo: :bar }
+    UniformNotifier::OpenTelemetryNotifier.out_of_channel_notify('notify otel')
+  end
+end


### PR DESCRIPTION
This introduces an [OpenTelemetry](https://opentelemetry.io/) notifier.