### PR TITLE
Update Honeybadger.notify signature to match new keyword style

### DIFF
--- a/lib/uniform_notifier/honeybadger.rb
+++ b/lib/uniform_notifier/honeybadger.rb
@@ -17,7 +17,7 @@ class UniformNotifier
 
         exception = Exception.new(message)
         honeybadger_class = opt[:honeybadger_class] || Honeybadger
-        honeybadger_class.notify(exception, opt)
+        honeybadger_class.notify(exception, **opt)
       end
     end
   end

--- a/spec/uniform_notifier/honeybadger_spec.rb
+++ b/spec/uniform_notifier/honeybadger_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe UniformNotifier::HoneybadgerNotifier do
   end
 
   it 'should notify honeybadger' do
-    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'), {})
+    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'))
 
     UniformNotifier.honeybadger = true
     UniformNotifier::HoneybadgerNotifier.out_of_channel_notify(title: 'notify honeybadger')
   end
 
   it 'should notify honeybadger' do
-    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'), { foo: :bar })
+    expect(Honeybadger).to receive(:notify).with(UniformNotifier::Exception.new('notify honeybadger'), foo: :bar)
 
     UniformNotifier.honeybadger = { foo: :bar }
     UniformNotifier::HoneybadgerNotifier.out_of_channel_notify('notify honeybadger')


### PR DESCRIPTION
A breaking change was introduced in the 6.0.0 version of the honeybadger gem. This PR updates the notify call to match the new keyword arg signature.

PR: https://github.com/honeybadger-io/honeybadger-ruby/pull/499
Changelog: https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md

